### PR TITLE
Fix ENTER instruction stack frame loop iteration

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -2507,7 +2507,7 @@ break;
             }
             if (lOp2Value.OpByte > 0)
             {
-                for (int c = 1; c < lOp2Value.OpByte - 1; c++)
+                for (int c = 1; c < lOp2Value.OpByte; c++)
                 {
                     if (!CurrentDecode.lOpSize16) //32 bit operand size
                     {


### PR DESCRIPTION
## Summary
- ensure ENTER sets up stack frame correctly by iterating nesting levels minus one

## Testing
- `dotnet test` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68a743e1b48883228bdf14a0e0adc04f