### PR TITLE
Fix IDIV overflow behavior and add tests

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -4217,27 +4217,53 @@ break;
             switch (CurrentDecode.Op1TypeCode)
             {
                 case TypeCode.Byte:
-                    Word lTempAX = Misc.SignExtend(mProc.regs.AL);
-                    mProc.regs.AL = (byte)(lTempAX / (Int16)CurrentDecode.Op1Value.OpByte);
-                    mProc.regs.AH = (byte)(lTempAX % (UInt16)CurrentDecode.Op1Value.OpByte);
-                    break;
+                    {
+                        Int16 dividend = (Int16)mProc.regs.AX;
+                        Int16 divisor = (sbyte)CurrentDecode.Op1Value.OpByte;
+                        Int16 quotient = (Int16)(dividend / divisor);
+                        Int16 remainder = (Int16)(dividend % divisor);
+                        if (quotient < sbyte.MinValue || quotient > sbyte.MaxValue)
+                        {
+                            CurrentDecode.ExceptionNumber = 0x00;
+                            CurrentDecode.ExceptionThrown = true;
+                            return;
+                        }
+                        mProc.regs.AL = (byte)quotient;
+                        mProc.regs.AH = (byte)remainder;
+                        break;
+                    }
                 case TypeCode.UInt16:
-                    if (Misc.IsNegative(mProc.regs.AX))
-                        mProc.regs.DX = 0xFFFF;
-                    UInt32 lDXAX = (UInt32)((mProc.regs.DX << 16) + mProc.regs.AX);
-                    mProc.regs.AX = (UInt16)((Int32)lDXAX / (Int32)CurrentDecode.Op1Value.OpWord);
-                    mProc.regs.DX = (UInt16)((Int32)lDXAX % (Int32)CurrentDecode.Op1Value.OpWord);
-                    //SetC the flags
-                    break;
+                    {
+                        Int32 dividend = (Int32)((mProc.regs.DX << 16) | mProc.regs.AX);
+                        Int32 divisor = (Int16)CurrentDecode.Op1Value.OpWord;
+                        Int32 quotient = dividend / divisor;
+                        Int32 remainder = dividend % divisor;
+                        if (quotient < Int16.MinValue || quotient > Int16.MaxValue)
+                        {
+                            CurrentDecode.ExceptionNumber = 0x00;
+                            CurrentDecode.ExceptionThrown = true;
+                            return;
+                        }
+                        mProc.regs.AX = (UInt16)quotient;
+                        mProc.regs.DX = (UInt16)remainder;
+                        break;
+                    }
                 case TypeCode.UInt32:
-                    if (Misc.IsNegative(mProc.regs.EAX))
-                        mProc.regs.EDX = 0xFFFFFFFF;
-                    Int64 lEDXEAX = mProc.regs.EDX;
-                    lEDXEAX <<= 32;
-                    lEDXEAX |= mProc.regs.EAX;
-                    mProc.regs.EAX = (UInt32)(lEDXEAX / (Int64)CurrentDecode.Op1Value.OpDWord);
-                    mProc.regs.EDX = (UInt32)(lEDXEAX % (Int64)CurrentDecode.Op1Value.OpDWord);
-                    break;
+                    {
+                        Int64 dividend = ((Int64)mProc.regs.EDX << 32) | mProc.regs.EAX;
+                        Int64 divisor = (Int32)CurrentDecode.Op1Value.OpDWord;
+                        Int64 quotient = dividend / divisor;
+                        Int64 remainder = dividend % divisor;
+                        if (quotient < Int32.MinValue || quotient > Int32.MaxValue)
+                        {
+                            CurrentDecode.ExceptionNumber = 0x00;
+                            CurrentDecode.ExceptionThrown = true;
+                            return;
+                        }
+                        mProc.regs.EAX = (UInt32)quotient;
+                        mProc.regs.EDX = (UInt32)remainder;
+                        break;
+                    }
                 #region Instructions
                 /*
             Operation

--- a/Virtual80x86Tests/InstructionTests.cs
+++ b/Virtual80x86Tests/InstructionTests.cs
@@ -142,5 +142,95 @@ namespace VirtualProcessor.Tests
 
 
         }
+
+        [TestMethod()]
+        public void IDIVByte_Success()
+        {
+            IDIV insIDIV = new IDIV() { mProc = mProc };
+            sIns = new sInstruction();
+            mProc.regs.AX = 0x0008;
+            sIns.Op1TypeCode = TypeCode.Byte;
+            sIns.Op1Value.OpByte = 0x02;
+            insIDIV.Impl(ref sIns);
+            Assert.IsFalse(sIns.ExceptionThrown, "IDIV byte success threw exception");
+            Assert.AreEqual((byte)4, mProc.regs.AL, "IDIV byte quotient");
+            Assert.AreEqual((byte)0, mProc.regs.AH, "IDIV byte remainder");
+        }
+
+        [TestMethod()]
+        public void IDIVByte_DivideError()
+        {
+            IDIV insIDIV = new IDIV() { mProc = mProc };
+            sIns = new sInstruction();
+            mProc.regs.AX = 0x7FFF;
+            sIns.Op1TypeCode = TypeCode.Byte;
+            sIns.Op1Value.OpByte = 0x01;
+            insIDIV.Impl(ref sIns);
+            Assert.IsTrue(sIns.ExceptionThrown, "IDIV byte divide error not thrown");
+            Assert.AreEqual(0x00, sIns.ExceptionNumber, "IDIV byte divide error code");
+            Assert.AreEqual(0x7FFF, mProc.regs.AX, "IDIV byte dividend modified");
+        }
+
+        [TestMethod()]
+        public void IDIVWord_Success()
+        {
+            IDIV insIDIV = new IDIV() { mProc = mProc };
+            sIns = new sInstruction();
+            mProc.regs.DX = 0x0000;
+            mProc.regs.AX = 0x8000;
+            sIns.Op1TypeCode = TypeCode.UInt16;
+            sIns.Op1Value.OpWord = 0x0002;
+            insIDIV.Impl(ref sIns);
+            Assert.IsFalse(sIns.ExceptionThrown, "IDIV word success threw exception");
+            Assert.AreEqual((UInt16)0x4000, mProc.regs.AX, "IDIV word quotient");
+            Assert.AreEqual((UInt16)0x0000, mProc.regs.DX, "IDIV word remainder");
+        }
+
+        [TestMethod()]
+        public void IDIVWord_DivideError()
+        {
+            IDIV insIDIV = new IDIV() { mProc = mProc };
+            sIns = new sInstruction();
+            mProc.regs.DX = 0x0001;
+            mProc.regs.AX = 0x0000;
+            sIns.Op1TypeCode = TypeCode.UInt16;
+            sIns.Op1Value.OpWord = 0x0001;
+            insIDIV.Impl(ref sIns);
+            Assert.IsTrue(sIns.ExceptionThrown, "IDIV word divide error not thrown");
+            Assert.AreEqual(0x00, sIns.ExceptionNumber, "IDIV word divide error code");
+            Assert.AreEqual((UInt16)0x0001, mProc.regs.DX, "IDIV word dividend modified (DX)");
+            Assert.AreEqual((UInt16)0x0000, mProc.regs.AX, "IDIV word dividend modified (AX)");
+        }
+
+        [TestMethod()]
+        public void IDIVDWord_Success()
+        {
+            IDIV insIDIV = new IDIV() { mProc = mProc };
+            sIns = new sInstruction();
+            mProc.regs.EDX = 0x00000000;
+            mProc.regs.EAX = 0x80000000;
+            sIns.Op1TypeCode = TypeCode.UInt32;
+            sIns.Op1Value.OpDWord = 0x00000002;
+            insIDIV.Impl(ref sIns);
+            Assert.IsFalse(sIns.ExceptionThrown, "IDIV dword success threw exception");
+            Assert.AreEqual(0x40000000u, mProc.regs.EAX, "IDIV dword quotient");
+            Assert.AreEqual(0x00000000u, mProc.regs.EDX, "IDIV dword remainder");
+        }
+
+        [TestMethod()]
+        public void IDIVDWord_DivideError()
+        {
+            IDIV insIDIV = new IDIV() { mProc = mProc };
+            sIns = new sInstruction();
+            mProc.regs.EDX = 0x00000002;
+            mProc.regs.EAX = 0x00000000;
+            sIns.Op1TypeCode = TypeCode.UInt32;
+            sIns.Op1Value.OpDWord = 0x00000001;
+            insIDIV.Impl(ref sIns);
+            Assert.IsTrue(sIns.ExceptionThrown, "IDIV dword divide error not thrown");
+            Assert.AreEqual(0x00, sIns.ExceptionNumber, "IDIV dword divide error code");
+            Assert.AreEqual(0x00000002u, mProc.regs.EDX, "IDIV dword dividend modified (EDX)");
+            Assert.AreEqual(0x00000000u, mProc.regs.EAX, "IDIV dword dividend modified (EAX)");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Correct IDIV to build signed dividend and check quotient range for all operand sizes
- Raise divide error when quotient exceeds destination width
- Add unit tests covering IDIV success and divide-error cases

## Testing
- `dotnet test` *(command not found: dotnet)*
- `apt-get update` *(403  Forbidden [IP: 172.30.0.227 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68a74495846083229c9b2f86ac80b6ab