### PR TITLE
Conditionally reset CX/ECX after INS

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -4635,7 +4635,7 @@ break;
         {
             UInt32 lDest, lJunk = 0;
 
-
+            bool repeating = mProc.mRepeatCondition != Processor_80x86.NOT_REPEAT;
             DWord lLoopCounter = mProc.mCurrInstructAddrSize16 ? mProc.regs.CX : mProc.regs.ECX;
 
             if (mProc.mRepeatCondition != Processor_80x86.NOT_REPEAT && ((lLoopCounter == 0)))
@@ -4687,11 +4687,14 @@ break;
                 //        mProc.regs.ECX--;
             }
             while (--lLoopCounter > 0 && mProc.mRepeatCondition != Processor_80x86.NOT_REPEAT);
-            if (mProc.mCurrInstructAddrSize16)
-                mProc.regs.CX = 0;
-            else
-                mProc.regs.ECX = 0;
-            mProc.mRepeatCondition = Processor_80x86.NOT_REPEAT;
+            if (repeating)
+            {
+                if (mProc.mCurrInstructAddrSize16)
+                    mProc.regs.CX = 0;
+                else
+                    mProc.regs.ECX = 0;
+                mProc.mRepeatCondition = Processor_80x86.NOT_REPEAT;
+            }
 
         }
     }


### PR DESCRIPTION
## Summary
- track repeat prefix state in INS and only clear CX/ECX and repeat flag when REP is active

## Testing
- `apt-get update` *(fails: repository InRelease not signed)*
- `sh build.sh` *(fails: gmcs not found)*
- `dotnet test Virtual80x86Tests/Virtual80x86Tests.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a74ab1a1c883228074e8bd0d89a446