### PR TITLE
Fix INT instruction clearing AC flag

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -4743,7 +4743,7 @@ break;
                     mProc.PUSH.Impl(ref ins);
                     mProc.regs.setFlagIF(false);
                     mProc.regs.setFlagTF(false);
-                    mProc.regs.setFlagAC(false);
+                    // mProc.regs.setFlagAC(false);
 
                     ins.Op1Add = Processor_80x86.RCS;
                     ins.Op1Value.OpDWord = mProc.regs.CS.Value;


### PR DESCRIPTION
## Summary
- Avoid clearing AC flag in INT instruction implementation; only IF and TF are cleared

## Testing
- `dotnet test Virtual80x86Tests/Virtual80x86Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a74d4fdff483229c40c2950b3ea35f