### PR TITLE
Fix LMSW to write low CR0 bits exactly

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -6818,7 +6818,7 @@ break;
         }
         public override void Impl(ref sInstruction CurrentDecode)
         {
-            mProc.regs.CR0 = (mProc.regs.CR0 & ~0x0F) | (CurrentDecode.Op1Value.OpWord & 0x0F);
+            mProc.regs.CR0 = (UInt32)((mProc.regs.CR0 & ~0x0F) | (CurrentDecode.Op1Value.OpWord & 0x0F));
             #region Instructions
             #endregion
         }

--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -6818,7 +6818,7 @@ break;
         }
         public override void Impl(ref sInstruction CurrentDecode)
         {
-            mProc.regs.CR0 |= (byte)(CurrentDecode.Op1Value.OpWord & 0x0f);
+            mProc.regs.CR0 = (mProc.regs.CR0 & ~0x0F) | (CurrentDecode.Op1Value.OpWord & 0x0F);
             #region Instructions
             #endregion
         }


### PR DESCRIPTION
## Summary
- Update LMSW instruction so CR0's low four bits are replaced with the operand

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a751de68408322b6a08f81fdf43b26