### PR TITLE
Use operand-size to select LOOP counter register

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -7006,7 +7006,7 @@ break;
         }
         public override void Impl(ref sInstruction CurrentDecode)
         {
-            if (mProc.mCurrInstructAddrSize16)
+            if (mProc.mCurrInstructOpSize16)
             {
                 if (--mProc.regs.CX != 0)
                     UpdIPForShortJump(CurrentDecode.Op1Value, CurrentDecode.Op1TypeCode);
@@ -7040,7 +7040,7 @@ break;
         }
         public override void Impl(ref sInstruction CurrentDecode)
         {
-            if (mProc.mAddrSize16)
+            if (mProc.mCurrInstructOpSize16)
             {
                 if ((--mProc.regs.CX != 0) & (mProc.regs.FLAGSB.ZF))
                     UpdIPForShortJump(CurrentDecode.Op1Value, CurrentDecode.Op1TypeCode);
@@ -7105,7 +7105,7 @@ break;
         }
         public void LoopNE_Logic(Processor_80x86 mProc, ref sInstruction CurrentDecode)
         {
-            if (mProc.mCurrInstructAddrSize16)
+            if (mProc.mCurrInstructOpSize16)
             {
                 if ((--mProc.regs.CX != 0) && (!mProc.regs.FLAGSB.ZF))
                 {

--- a/Virtual80x86Tests/LoopTests.cs
+++ b/Virtual80x86Tests/LoopTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VirtualProcessor;
+using System;
+
+namespace VirtualProcessor.Tests
+{
+    [TestClass]
+    public class LoopTests
+    {
+        PCSystem mSystem;
+        Processor_80x86 mProc;
+        LOOP loop;
+        LOOPNE loopne;
+        sInstruction sIns;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            uint mem = 1024 * 1024;
+            mSystem = new PCSystem(mem, eProcTypes.i80386, @"");
+            mProc = new Processor_80x86(mSystem, mem, eProcTypes.i80386);
+            sIns = new sInstruction();
+            loop = new LOOP() { mProc = mProc };
+            loopne = new LOOPNE() { mProc = mProc };
+        }
+
+        [TestMethod]
+        public void LoopUsesCXWhenOpSize16()
+        {
+            mProc.mCurrInstructOpSize16 = true;
+            mProc.regs.ECX = 0x00010000;
+            sIns.Op1Value.OpSByte = 0;
+            sIns.Op1TypeCode = TypeCode.SByte;
+
+            loop.Impl(ref sIns);
+
+            Assert.AreEqual(0x0001FFFFu, mProc.regs.ECX, "LOOP should operate on CX for 16-bit operand size");
+        }
+
+        [TestMethod]
+        public void LoopUsesECXWhenOpSize32()
+        {
+            mProc.mCurrInstructOpSize16 = false;
+            mProc.regs.ECX = 0x00010000;
+            sIns.Op1Value.OpSByte = 0;
+            sIns.Op1TypeCode = TypeCode.SByte;
+
+            loop.Impl(ref sIns);
+
+            Assert.AreEqual(0x0000FFFFu, mProc.regs.ECX, "LOOP should operate on ECX for 32-bit operand size");
+        }
+
+        [TestMethod]
+        public void LoopNEUsesCXWhenOpSize16()
+        {
+            mProc.mCurrInstructOpSize16 = true;
+            mProc.regs.ECX = 0x00010000;
+            mProc.regs.FLAGSB.ZF = false;
+            sIns.Op1Value.OpSByte = 0;
+            sIns.Op1TypeCode = TypeCode.SByte;
+
+            loopne.Impl(ref sIns);
+
+            Assert.AreEqual(0x0001FFFFu, mProc.regs.ECX, "LOOPNE should operate on CX for 16-bit operand size");
+        }
+
+        [TestMethod]
+        public void LoopNEUsesECXWhenOpSize32()
+        {
+            mProc.mCurrInstructOpSize16 = false;
+            mProc.regs.ECX = 0x00010000;
+            mProc.regs.FLAGSB.ZF = false;
+            sIns.Op1Value.OpSByte = 0;
+            sIns.Op1TypeCode = TypeCode.SByte;
+
+            loopne.Impl(ref sIns);
+
+            Assert.AreEqual(0x0000FFFFu, mProc.regs.ECX, "LOOPNE should operate on ECX for 32-bit operand size");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Fix LOOP-family instructions to choose CX or ECX based on operand-size override
- Add tests exercising LOOP and LOOPNE with 16-bit and 32-bit operand sizes

## Testing
- ⚠️ `dotnet test Virtual80x86Tests/Virtual80x86Tests.csproj` *(`dotnet` not installed, attempted but command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a758d631348322bc3c8892d5533558