### PR TITLE
Fix NEG overflow handling and add tests

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -7771,23 +7771,21 @@ break;
                 case TypeCode.Byte:
                     lOp1Val.OpByte = (byte)-(lOp1Val.OpByte);
                     mProc.mem.SetByte(mProc, ref CurrentDecode, CurrentDecode.Op1Add, lOp1Val.OpByte);
-                    mProc.regs.setFlagOF_Sub(lPreVal1.OpByte, (byte)-(lOp1Val.OpByte), lOp1Val.OpByte);
                     break;
                 case TypeCode.UInt16:
                     lOp1Val.OpWord = (Word)(-(lOp1Val.OpWord));
                     mProc.mem.SetWord(mProc, ref CurrentDecode, CurrentDecode.Op1Add, lOp1Val.OpWord);
-                    mProc.regs.setFlagOF_Sub(lPreVal1.OpWord, (Word)(-(lOp1Val.OpWord)), lOp1Val.OpWord);
                     break;
                 case TypeCode.UInt32:
                     lOp1Val.OpDWord = (DWord)(-(lOp1Val.OpDWord));
                     mProc.mem.SetDWord(mProc, ref CurrentDecode, CurrentDecode.Op1Add, lOp1Val.OpDWord);
-                    mProc.regs.setFlagOF_Sub(lPreVal1.OpDWord, (Word)(-(lOp1Val.OpDWord)), lOp1Val.OpDWord);
                     break;
                 default:
                     throw new Exception("Cannot negate a quad word");
             }
 
-            SetFlagsForSubtraction(mProc, lPreVal1, CurrentDecode.Op1Value, lOp1Val, CurrentDecode.Op1TypeCode);
+            sOpVal zero = new sOpVal();
+            SetFlagsForSubtraction(mProc, zero, lPreVal1, lOp1Val, CurrentDecode.Op1TypeCode);
 
             #region Instructions
             #endregion

--- a/Virtual80x86Tests/NEGTests.cs
+++ b/Virtual80x86Tests/NEGTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using VirtualProcessor;
+using System;
+
+namespace VirtualProcessor.Tests
+{
+    [TestClass]
+    public class NEGTests
+    {
+        private Processor_80x86 CreateProcessor()
+        {
+            uint memSize = 16 * 1024 * 1024;
+            eProcTypes processorType = eProcTypes.i80386;
+            PCSystem system = new PCSystem(memSize, processorType, "");
+            return new Processor_80x86(system, memSize, processorType);
+        }
+
+        [TestMethod]
+        public void NegByteOverflowOnlyForMinValue()
+        {
+            var proc = CreateProcessor();
+            var neg = new NEG() { mProc = proc };
+            sInstruction ins = new sInstruction();
+            ins.Op1TypeCode = TypeCode.Byte;
+            ins.Op1Add = Processor_80x86.RAL;
+
+            proc.regs.AL = 0x80;
+            ins.Op1Value.OpByte = proc.regs.AL;
+            neg.Impl(ref ins);
+            Assert.IsTrue(proc.regs.FLAGSB.OF, "OF should be set for 0x80");
+
+            proc.regs.AL = 0x7F;
+            ins = new sInstruction();
+            ins.Op1TypeCode = TypeCode.Byte;
+            ins.Op1Add = Processor_80x86.RAL;
+            ins.Op1Value.OpByte = proc.regs.AL;
+            neg.Impl(ref ins);
+            Assert.IsFalse(proc.regs.FLAGSB.OF, "OF should be clear for 0x7F");
+        }
+
+        [TestMethod]
+        public void NegWordOverflowOnlyForMinValue()
+        {
+            var proc = CreateProcessor();
+            var neg = new NEG() { mProc = proc };
+            sInstruction ins = new sInstruction();
+            ins.Op1TypeCode = TypeCode.UInt16;
+            ins.Op1Add = Processor_80x86.RAX;
+
+            proc.regs.AX = 0x8000;
+            ins.Op1Value.OpWord = proc.regs.AX;
+            neg.Impl(ref ins);
+            Assert.IsTrue(proc.regs.FLAGSB.OF, "OF should be set for 0x8000");
+
+            proc.regs.AX = 0x7FFF;
+            ins = new sInstruction();
+            ins.Op1TypeCode = TypeCode.UInt16;
+            ins.Op1Add = Processor_80x86.RAX;
+            ins.Op1Value.OpWord = proc.regs.AX;
+            neg.Impl(ref ins);
+            Assert.IsFalse(proc.regs.FLAGSB.OF, "OF should be clear for 0x7FFF");
+        }
+
+        [TestMethod]
+        public void NegDWordOverflowOnlyForMinValue()
+        {
+            var proc = CreateProcessor();
+            var neg = new NEG() { mProc = proc };
+            sInstruction ins = new sInstruction();
+            ins.Op1TypeCode = TypeCode.UInt32;
+            ins.Op1Add = Processor_80x86.RAX;
+
+            proc.regs.EAX = 0x80000000;
+            ins.Op1Value.OpDWord = proc.regs.EAX;
+            neg.Impl(ref ins);
+            Assert.IsTrue(proc.regs.FLAGSB.OF, "OF should be set for 0x80000000");
+
+            proc.regs.EAX = 0x7FFFFFFF;
+            ins = new sInstruction();
+            ins.Op1TypeCode = TypeCode.UInt32;
+            ins.Op1Add = Processor_80x86.RAX;
+            ins.Op1Value.OpDWord = proc.regs.EAX;
+            neg.Impl(ref ins);
+            Assert.IsFalse(proc.regs.FLAGSB.OF, "OF should be clear for 0x7FFFFFFF");
+        }
+    }
+}

--- a/Virtual80x86Tests/Virtual80x86Tests.csproj
+++ b/Virtual80x86Tests/Virtual80x86Tests.csproj
@@ -59,6 +59,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="InstructionTests.cs" />
+    <Compile Include="NEGTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Correct NEG flag computation to subtract from zero
- Add unit tests verifying overflow occurs only for most negative operands

## Testing
- `dotnet test Virtual80x86Tests/Virtual80x86Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a760ba3aac8322aea5851ecc6c25e3