### PR TITLE
Guard OUTS counter when REP prefix absent

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -7993,7 +7993,7 @@ break;
         }
         public override void Impl(ref sInstruction CurrentDecode)
         {
-
+            bool repeating = mProc.mRepeatCondition != Processor_80x86.NOT_REPEAT;
 
             DWord lSource, lJunk = 0;
             DWord lLoopCounter = mProc.mCurrInstructAddrSize16 ? mProc.regs.CX : mProc.regs.ECX;
@@ -8034,11 +8034,14 @@ break;
             }
             while (--lLoopCounter > 0 && mProc.mRepeatCondition != Processor_80x86.NOT_REPEAT);
 
-            if (mProc.mCurrInstructAddrSize16)
-                mProc.regs.CX = 0;
-            else
-                mProc.regs.ECX = 0;
-            mProc.mRepeatCondition = Processor_80x86.NOT_REPEAT;
+            if (repeating)
+            {
+                if (mProc.mCurrInstructAddrSize16)
+                    mProc.regs.CX = 0;
+                else
+                    mProc.regs.ECX = 0;
+                mProc.mRepeatCondition = Processor_80x86.NOT_REPEAT;
+            }
         }
     }
     public class POP : Instruct

--- a/Virtual80x86Tests/InstructionTests.cs
+++ b/Virtual80x86Tests/InstructionTests.cs
@@ -27,6 +27,7 @@ namespace VirtualProcessor.Tests
         static ADC insADC;
         static STC insSTC;
         static CLC insCLC;
+        static OUTS insOUTS;
 
 
         [AssemblyInitialize]
@@ -43,6 +44,7 @@ namespace VirtualProcessor.Tests
             insADC = new ADC() { mProc = mProc };
             insSTC = new STC() { mProc = mProc };
             insCLC = new CLC() { mProc = mProc };
+            insOUTS = new OUTS() { mProc = mProc };
         }
 
         [TestMethod()]
@@ -141,6 +143,24 @@ namespace VirtualProcessor.Tests
             //TEST: ADD
 
 
+        }
+
+        [TestMethod()]
+        public void OUTSWithoutRepLeavesCounter()
+        {
+            var ins = new sInstruction();
+            ins.RealOpCode = 0x6F;
+            mProc.mCurrInstructAddrSize16 = true;
+            mProc.regs.CX = 5;
+            mProc.regs.SI = 0;
+            mProc.regs.ES.Value = 0;
+            mProc.regs.DX = 0;
+            mProc.mem.SetDWord(mProc, ref ins, 0, 0x12345678);
+            mProc.mRepeatCondition = Processor_80x86.NOT_REPEAT;
+
+            insOUTS.Impl(ref ins);
+
+            Assert.AreEqual((UInt16)5, mProc.regs.CX, "OUTS should not modify CX without REP");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Capture repeat status in `OUTS` and only clear CX/ECX when a repeat prefix is active
- Add test ensuring OUTS does not zero CX without REP

## Testing
- ❌ `dotnet test Virtual80x86Tests/Virtual80x86Tests.csproj` *(dotnet missing)*
- ⚠️ `apt-get update` *(403: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7619730588322a6013c7123d258e5