### PR TITLE
Propagate POPF exceptions properly

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -8204,9 +8204,10 @@ break;
             mProc.POP.mNoSetMemoryToValue = true;
             ins.Operand1IsRef = false;
             mProc.POP.Impl(ref ins);
-            if (ins.ExceptionThrown)
-            {
-
+            if (ins.ExceptionThrown) {
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
                 return;
             }
             lTempFlags = ins.Op1Value.OpDWord;


### PR DESCRIPTION
## Summary
- ensure POPF propagates exception information when pop fails

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a766cd908083229baee88eb7aa108f