### PR TITLE
Add exception propagation after each PUSHAD push

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -8458,23 +8458,74 @@ break;
             mProc.PUSH.Impl(ref ins);
             if (ins.ExceptionThrown)
             {
-                
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
                 return;
             }
             ins.Op1Value.OpDWord = mProc.regs.ECX;
             mProc.PUSH.Impl(ref ins);
+            if (ins.ExceptionThrown)
+            {
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
+                return;
+            }
             ins.Op1Value.OpDWord = mProc.regs.EDX;
             mProc.PUSH.Impl(ref ins);
+            if (ins.ExceptionThrown)
+            {
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
+                return;
+            }
             ins.Op1Value.OpDWord = mProc.regs.EBX;
             mProc.PUSH.Impl(ref ins);
+            if (ins.ExceptionThrown)
+            {
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
+                return;
+            }
             ins.Op1Value.OpDWord = lOrigESP;
             mProc.PUSH.Impl(ref ins);
+            if (ins.ExceptionThrown)
+            {
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
+                return;
+            }
             ins.Op1Value.OpDWord = mProc.regs.EBP;
             mProc.PUSH.Impl(ref ins);
+            if (ins.ExceptionThrown)
+            {
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
+                return;
+            }
             ins.Op1Value.OpDWord = mProc.regs.ESI;
             mProc.PUSH.Impl(ref ins);
+            if (ins.ExceptionThrown)
+            {
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
+                return;
+            }
             ins.Op1Value.OpDWord = mProc.regs.EDI;
             mProc.PUSH.Impl(ref ins);
+            if (ins.ExceptionThrown)
+            {
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
+                return;
+            }
 
         }
     }


### PR DESCRIPTION
## Summary
- ensure PUSHAD stops on faults by propagating exception info after each register push

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a768e7488083228d094907cd16584d