### PR TITLE
Propagate exceptions in PUSHF

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -8507,7 +8507,9 @@ break;
                 mProc.PUSH.Impl(ref ins);
                 if (ins.ExceptionThrown)
                 {
-                    
+                    CurrentDecode.ExceptionThrown = true;
+                    CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                    CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
                     return;
                 }
             }
@@ -8518,7 +8520,9 @@ break;
                 mProc.PUSH.Impl(ref ins);
                 if (ins.ExceptionThrown)
                 {
-                    
+                    CurrentDecode.ExceptionThrown = true;
+                    CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                    CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
                     return;
                 }
             }


### PR DESCRIPTION
## Summary
- forward PUSH exceptions in PUSHF to current decode

## Testing
- `dotnet test Virtual80x86Tests/Virtual80x86Tests.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a76980fc7483229603382bc066934a