### PR TITLE
Fix RCR overflow flag calculation

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -8657,12 +8657,6 @@ break;
                 case TypeCode.UInt64: lTopBitNum = 63; break;
 
             }
-            if (CurrentDecode.Op2Value.OpByte == 1)
-            {
-                int lMSBDest = Misc.getBit(lOp1Value.OpQWord, lTopBitNum);
-                int lXORd = lMSBDest ^ (mProc.regs.FLAGS & 0x01);
-                mProc.regs.setFlagOF(lXORd == 1);
-            }
 
             //Do the operation
             switch (CurrentDecode.Op1TypeCode)
@@ -8711,6 +8705,12 @@ break;
                     }
                     mProc.mem.SetQWord(mProc, ref CurrentDecode, CurrentDecode.Op1Add, lOp1Value.OpQWord);
                     break;
+            }
+
+            if (CurrentDecode.Op2Value.OpByte == 1) {
+                int msb  = Misc.getBit(lOp1Value.OpQWord, lTopBitNum);
+                int next = Misc.getBit(lOp1Value.OpQWord, lTopBitNum - 1);
+                mProc.regs.setFlagOF((msb ^ next) == 1);
             }
 
             #region Instructions


### PR DESCRIPTION
## Summary
- compute RCR overflow flag from rotated result's top bits

## Testing
- ⚠️ `dotnet build Virtual8086.sln` (dotnet: command not found)
- ⚠️ `dotnet test Virtual8086.sln` (dotnet: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a77f8e12bc8322945af51e230c40ab