### PR TITLE
Fix RDTSC to use 64-bit TSC and add tests

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -8936,8 +8936,9 @@ break;
         }
         public override void Impl(ref sInstruction CurrentDecode)
         {
-            mProc.regs.EAX = (UInt32)mProc.mInsructionsExecuted * 25;
-            mProc.regs.EDX = (UInt32)(((mProc.mInsructionsExecuted * 25) & 0xFFFFFFFF00000000) >> 32);
+            UInt64 tsc = mProc.mInsructionsExecuted * 25;
+            mProc.regs.EAX = (UInt32)tsc;
+            mProc.regs.EDX = (UInt32)(tsc >> 32);
             #region Instructions
             #endregion
         }

--- a/Virtual80x86Tests/InstructionTests.cs
+++ b/Virtual80x86Tests/InstructionTests.cs
@@ -27,6 +27,7 @@ namespace VirtualProcessor.Tests
         static ADC insADC;
         static STC insSTC;
         static CLC insCLC;
+        static RDTSC insRDTSC;
 
 
         [AssemblyInitialize]
@@ -43,6 +44,7 @@ namespace VirtualProcessor.Tests
             insADC = new ADC() { mProc = mProc };
             insSTC = new STC() { mProc = mProc };
             insCLC = new CLC() { mProc = mProc };
+            insRDTSC = new RDTSC() { mProc = mProc };
         }
 
         [TestMethod()]
@@ -59,6 +61,18 @@ namespace VirtualProcessor.Tests
             insAAA.Impl(ref sIns);
             Assert.AreEqual(0x0101, mProc.regs.AX, "AAA test failed");
 
+        }
+
+        [TestMethod()]
+        public void RDTSC64BitTest()
+        {
+            sIns = new sInstruction();
+            mProc.InstructionsExecuted = 0x100000001;
+            mProc.regs.EAX = 0;
+            mProc.regs.EDX = 0;
+            insRDTSC.Impl(ref sIns);
+            Assert.AreEqual(0x00000019u, mProc.regs.EAX, "RDTSC low dword incorrect");
+            Assert.AreEqual(0x00000019u, mProc.regs.EDX, "RDTSC high dword incorrect");
         }
 
         [TestMethod()]


### PR DESCRIPTION
## Summary
- compute RDTSC timestamp in 64 bits and split into EAX/EDX
- add unit test validating 64-bit RDTSC behavior

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7808423148322b5aa3333ae23f6fa