### PR TITLE
Propagate exceptions in return instructions

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -8868,7 +8868,9 @@ break;
             }
             if (ins.ExceptionThrown)
             {
-                
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
                 return;
             }
             ins.Op1Add = 0;
@@ -8906,11 +8908,20 @@ break;
             mProc.POP.Impl(ref ins);
             if (ins.ExceptionThrown)
             {
-                
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
                 return;
             }
             ins.Op1Add = Processor_80x86.RCS;
             mProc.POP.Impl(ref ins);
+            if (ins.ExceptionThrown)
+            {
+                CurrentDecode.ExceptionThrown = true;
+                CurrentDecode.ExceptionNumber = ins.ExceptionNumber;
+                CurrentDecode.ExceptionErrorCode = ins.ExceptionErrorCode;
+                return;
+            }
             ins.Op1Add = 0x0;
             //TODO: Need to update for StackSize=32
                 mProc.regs.SP += (UInt16)(CurrentDecode.Op1Value.OpWord & 0xFFFF);


### PR DESCRIPTION
## Summary
- Propagate fault info after POP in RET
- Ensure RETF forwards POP exceptions for both EIP and CS pops

## Testing
- `dotnet test Virtual80x86Tests/Virtual80x86Tests.csproj` *(fails: command not found)*
- `bash build.sh` *(fails: gmcs: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77ff41f00832294b4e7e0d8cbc868