### PR TITLE
Fix ROR overflow flag logic and add tests

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -9067,9 +9067,9 @@ break;
             mProc.regs.setFlagCF(Misc.getBit(lOp1Value.OpQWord, lTopBitNum) == 1);
             if (CurrentDecode.Op2Value.OpByte == 1)
             {
-                int lMSBDest = Misc.getBit(lOp1Value.OpQWord, lTopBitNum);
-                int lXORd = lMSBDest ^ (mProc.regs.FLAGS & 0x01);
-                mProc.regs.setFlagOF(lXORd == 1);
+                int msb  = Misc.getBit(lOp1Value.OpQWord, lTopBitNum);
+                int next = Misc.getBit(lOp1Value.OpQWord, lTopBitNum - 1);
+                mProc.regs.setFlagOF((msb ^ next) == 1);
             }
 
             #region Instructions

--- a/Virtual80x86Tests/RotateTests.cs
+++ b/Virtual80x86Tests/RotateTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using VirtualProcessor;
+
+namespace VirtualProcessor.Tests
+{
+    [TestClass]
+    public class RotateTests
+    {
+        private Processor_80x86 BuildProc()
+        {
+            uint memSize = 1024 * 1024;
+            eProcTypes procType = eProcTypes.i80386;
+            PCSystem system = new PCSystem(memSize, procType, "");
+            return new Processor_80x86(system, memSize, procType);
+        }
+
+        [TestMethod]
+        public void RorSetsOFWhenTopBitsDiffer()
+        {
+            var proc = BuildProc();
+            var ror = new ROR() { mProc = proc };
+            sInstruction ins = new sInstruction();
+            ins.Op1TypeCode = TypeCode.Byte;
+            ins.Op1Add = Processor_80x86.RAL;
+            ins.Op1Value.OpByte = 0x80;
+            ins.Op2TypeCode = TypeCode.Byte;
+            ins.Op2Value.OpByte = 1;
+            ins.Operand1IsRef = false;
+            ins.Operand2IsRef = false;
+
+            proc.regs.AL = 0x80;
+            ror.Impl(ref ins);
+
+            Assert.IsTrue(proc.regs.FLAGSB.OF, "OF should be set when high bits differ");
+        }
+
+        [TestMethod]
+        public void RorClearsOFWhenTopBitsSame()
+        {
+            var proc = BuildProc();
+            var ror = new ROR() { mProc = proc };
+            sInstruction ins = new sInstruction();
+            ins.Op1TypeCode = TypeCode.Byte;
+            ins.Op1Add = Processor_80x86.RAL;
+            ins.Op1Value.OpByte = 0x40;
+            ins.Op2TypeCode = TypeCode.Byte;
+            ins.Op2Value.OpByte = 1;
+            ins.Operand1IsRef = false;
+            ins.Operand2IsRef = false;
+
+            proc.regs.AL = 0x40;
+            ror.Impl(ref ins);
+
+            Assert.IsFalse(proc.regs.FLAGSB.OF, "OF should be clear when high bits are same");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Correct OF flag computation in ROR to XOR the two highest bits after rotation
- Add unit tests checking ROR overflow flag behavior for differing and matching high bits

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a782d8f65c832283cf1ac32afb22d6