### PR TITLE
Fix SAHF to preserve reserved flag bits

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -9109,7 +9109,8 @@ break;
             //sTempFlags += Misc.getBit(mProc.regs.AH, 0);
 
             //08/27/10 - changed from ^= to=  **** OMG THIS FIXED IT, A> prompt!!! ****
-            mProc.regs.FLAGS = (Word)((mProc.regs.FLAGS & 0xFF00) + mProc.regs.AH);
+            //03/17/24 - updated to preserve reserved flag bits when loading from AH
+            mProc.regs.FLAGS = (Word)((mProc.regs.FLAGS & ~0x00D5) | (mProc.regs.AH & 0xD5));
             #region Instructions
             /*
               Operation

--- a/Virtual80x86Tests/InstructionTests.cs
+++ b/Virtual80x86Tests/InstructionTests.cs
@@ -27,6 +27,7 @@ namespace VirtualProcessor.Tests
         static ADC insADC;
         static STC insSTC;
         static CLC insCLC;
+        static SAHF insSAHF;
 
 
         [AssemblyInitialize]
@@ -43,6 +44,7 @@ namespace VirtualProcessor.Tests
             insADC = new ADC() { mProc = mProc };
             insSTC = new STC() { mProc = mProc };
             insCLC = new CLC() { mProc = mProc };
+            insSAHF = new SAHF() { mProc = mProc };
         }
 
         [TestMethod()]
@@ -141,6 +143,24 @@ namespace VirtualProcessor.Tests
             //TEST: ADD
 
 
+        }
+
+        [TestMethod()]
+        public void SAHFTests()
+        {
+            sIns = new sInstruction();
+
+            // Ensure reserved bits (1,3,5) are not modified when clearing flags
+            mProc.regs.FLAGS = 0xFF; // set all bits
+            mProc.regs.AH = 0x00;    // clear all status flag bits
+            insSAHF.Impl(ref sIns);
+            Assert.AreEqual(0x2A, mProc.regs.FLAGS & 0xFF, "SAHF did not preserve reserved bits when clearing flags");
+
+            // Ensure status flags update while reserved bits remain unchanged
+            mProc.regs.FLAGS = 0x00; // reserved bits start cleared
+            mProc.regs.AH = 0xFF;    // set all flag bits in AH
+            insSAHF.Impl(ref sIns);
+            Assert.AreEqual(0xD5, mProc.regs.FLAGS & 0xFF, "SAHF did not correctly set status flags");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Preserve reserved flag bits in SAHF by masking out bits 7,6,4,2,0
- Add unit tests verifying SAHF updates status flags without altering reserved bits

## Testing
- ⚠️ `dotnet restore Virtual80x86.sln` (command not found)
- ⚠️ `apt-get update` (403 Forbidden)
- ⚠️ `sh build.sh` (gmcs: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a78341bb188322a5046b8d5ec882d4