### PR TITLE
Handle zero shift count in SAR

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -9207,6 +9207,9 @@ break;
             if (mProc.ProcType > eProcTypes.i8086)
                 lTempCount = lTempCount & 0x1F;
 
+            if (lTempCount == 0)
+                return;
+
             if (CurrentDecode.Op1Value.OpDWord >= 0x80000000)
                 lTempCount = lTempCount + 1 - 1;
 


### PR DESCRIPTION
## Summary
- exit SAR early when shift count is zero to preserve operand and flags

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7857be694832293c350ad7ba8f79c