### PR TITLE
Fix SHR CF/OF flag handling

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -9800,6 +9800,7 @@ break;
         {
             int lTempCount = CurrentDecode.Op2Value.OpByte, lTopBitNum = 0;
             sOpVal lOp1Value = CurrentDecode.Op1Value;
+            sOpVal original = lOp1Value;
 
             if (mProc.ProcType > eProcTypes.i8086)
                 lTempCount = lTempCount & 0x1F;
@@ -9822,7 +9823,7 @@ break;
                     for (UInt16 cnt = 0; (cnt) < lTempCount; cnt++)
                     {
                         if (cnt == lTempCount - 1)
-                            mProc.regs.setFlagCF((lOp1Value.OpByte & 0x01) == 1);
+                            mProc.regs.setFlagCF((lOp1Value.OpWord & 0x01) == 1);
                         lOp1Value.OpWord /= 2;
                     }
                     mProc.mem.SetWord(mProc, ref CurrentDecode, CurrentDecode.Op1Add, lOp1Value.OpWord);
@@ -9833,7 +9834,7 @@ break;
                     for (UInt16 cnt = 0; (cnt) < lTempCount; cnt++)
                     {
                         if (cnt == lTempCount - 1)
-                            mProc.regs.setFlagCF((lOp1Value.OpByte & 0x01) == 1);
+                            mProc.regs.setFlagCF((lOp1Value.OpDWord & 0x01) == 1);
                         lOp1Value.OpDWord /= 2;
                     }
                     mProc.mem.SetDWord(mProc, ref CurrentDecode, CurrentDecode.Op1Add, lOp1Value.OpDWord);
@@ -9844,7 +9845,7 @@ break;
                     for (UInt16 cnt = 0; (cnt) < lTempCount; cnt++)
                     {
                         if (cnt == lTempCount - 1)
-                            mProc.regs.setFlagCF((lOp1Value.OpByte & 0x01) == 1);
+                            mProc.regs.setFlagCF((lOp1Value.OpQWord & 0x01) == 1);
                         lOp1Value.OpQWord /= 2;
                     }
                     mProc.mem.SetQWord(mProc, ref CurrentDecode, CurrentDecode.Op1Add, lOp1Value.OpQWord);
@@ -9854,8 +9855,8 @@ break;
 
             if (lTempCount == 1)
             {
-                bool lTempOF = ((Misc.getBit(lOp1Value.OpQWord, lTopBitNum)) == 1);
-                mProc.regs.setFlagOF(lTempOF);
+                bool msb = Misc.getBit(original.OpQWord, lTopBitNum) == 1;
+                mProc.regs.setFlagOF(msb);
             }
             mProc.regs.setFlagPF(lOp1Value.OpQWord);
             mProc.regs.setFlagZF(lOp1Value.OpQWord);

--- a/Virtual80x86Tests/InstructionTests.cs
+++ b/Virtual80x86Tests/InstructionTests.cs
@@ -27,6 +27,7 @@ namespace VirtualProcessor.Tests
         static ADC insADC;
         static STC insSTC;
         static CLC insCLC;
+        static SHR insSHR;
 
 
         [AssemblyInitialize]
@@ -43,6 +44,7 @@ namespace VirtualProcessor.Tests
             insADC = new ADC() { mProc = mProc };
             insSTC = new STC() { mProc = mProc };
             insCLC = new CLC() { mProc = mProc };
+            insSHR = new SHR() { mProc = mProc };
         }
 
         [TestMethod()]
@@ -141,6 +143,80 @@ namespace VirtualProcessor.Tests
             //TEST: ADD
 
 
+        }
+
+        [TestMethod()]
+        public void SHRByteFlags()
+        {
+            sInstruction ins = new sInstruction();
+            mProc.regs.setFlagCF(false);
+            mProc.regs.setFlagOF(false);
+            mProc.regs.AL = 0x81;
+            ins.Op1TypeCode = TypeCode.Byte;
+            ins.Op1Value.OpByte = 0x81;
+            ins.Op1Add = Processor_80x86.RAL;
+            ins.Op2TypeCode = TypeCode.Byte;
+            ins.Op2Value.OpByte = 1;
+            insSHR.Impl(ref ins);
+            Assert.AreEqual(0x40, mProc.regs.AL);
+            Assert.IsTrue(mProc.regs.FLAGSB.CF);
+            Assert.IsTrue(mProc.regs.FLAGSB.OF);
+        }
+
+        [TestMethod()]
+        public void SHRWordFlags()
+        {
+            sInstruction ins = new sInstruction();
+            mProc.regs.setFlagCF(false);
+            mProc.regs.setFlagOF(false);
+            mProc.regs.AX = 0x8001;
+            ins.Op1TypeCode = TypeCode.UInt16;
+            ins.Op1Value.OpWord = 0x8001;
+            ins.Op1Add = Processor_80x86.RAX;
+            ins.Op2TypeCode = TypeCode.Byte;
+            ins.Op2Value.OpByte = 1;
+            insSHR.Impl(ref ins);
+            Assert.AreEqual(0x4000, mProc.regs.AX);
+            Assert.IsTrue(mProc.regs.FLAGSB.CF);
+            Assert.IsTrue(mProc.regs.FLAGSB.OF);
+        }
+
+        [TestMethod()]
+        public void SHRDWordFlags()
+        {
+            sInstruction ins = new sInstruction();
+            mProc.regs.setFlagCF(false);
+            mProc.regs.setFlagOF(false);
+            mProc.regs.EAX = 0x80000001;
+            ins.Op1TypeCode = TypeCode.UInt32;
+            ins.Op1Value.OpDWord = 0x80000001;
+            ins.Op1Add = Processor_80x86.REAX;
+            ins.Op2TypeCode = TypeCode.Byte;
+            ins.Op2Value.OpByte = 1;
+            insSHR.Impl(ref ins);
+            Assert.AreEqual((UInt32)0x40000000, mProc.regs.EAX);
+            Assert.IsTrue(mProc.regs.FLAGSB.CF);
+            Assert.IsTrue(mProc.regs.FLAGSB.OF);
+        }
+
+        [TestMethod()]
+        public void SHRQWordFlags()
+        {
+            sInstruction ins = new sInstruction();
+            mProc.regs.setFlagCF(false);
+            mProc.regs.setFlagOF(false);
+            UInt32 addr = 0x2000;
+            ins.Op1TypeCode = TypeCode.UInt64;
+            ins.Op1Value.OpQWord = 0x8000000000000001;
+            ins.Op1Add = addr;
+            ins.Op2TypeCode = TypeCode.Byte;
+            ins.Op2Value.OpByte = 1;
+            mProc.mem.SetQWord(mProc, ref ins, addr, ins.Op1Value.OpQWord);
+            insSHR.Impl(ref ins);
+            UInt64 result = mProc.mem.GetQWord(mProc, ref ins, addr);
+            Assert.AreEqual(0x4000000000000000, result);
+            Assert.IsTrue(mProc.regs.FLAGSB.CF);
+            Assert.IsTrue(mProc.regs.FLAGSB.OF);
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix CF logic for SHR across 16/32/64-bit operands
- compute OF from original most significant bit
- add unit tests for SHR flag behavior across operand sizes

## Testing
- `dotnet test Virtual80x86Tests/Virtual80x86Tests.csproj -p:EnableWindowsTargeting=true` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a789d7590c8322a82e236fa9ec5409