### PR TITLE
Fix SHRD overflow flag handling

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -9931,6 +9931,12 @@ break;
             mProc.regs.setFlagPF(Dest.OpQWord);
             mProc.regs.setFlagZF(Dest.OpQWord);
 
+            if (Count == 1) {
+                int msb  = Misc.getBit(Dest.OpQWord, Size - 1);
+                int next = Misc.getBit(Dest.OpQWord, Size - 2);
+                mProc.regs.setFlagOF((msb ^ next) == 1);
+            }
+
             #region Instructions
             #endregion
         }


### PR DESCRIPTION
## Summary
- update `SHRD` implementation so overflow flag reflects XOR of top two bits when shifting once

## Testing
- `dotnet test Virtual80x86Tests/Virtual80x86Tests.csproj` *(fails: command not found)*
- `apt-get install -y mono-complete` *(fails: Unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_68a78df0d1808322ad176cd135912778