### PR TITLE
Fix SLDT to store segment selector only

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -10092,17 +10092,12 @@ break;
         }
         public override void Impl(ref sInstruction CurrentDecode)
         {
-            UInt16 lLimit;
-            UInt32 lBase;
-
-            lLimit = (UInt16)mProc.regs.LDTR.Limit;
-            lBase = mProc.regs.LDTR.Base;
-
-            if (CurrentDecode.lOpSize16)
-                lBase &= 0x00FFFFFF;
-
-            mProc.mem.SetWord(mProc, ref CurrentDecode, CurrentDecode.Op1Add, lLimit);
-            mProc.mem.SetDWord(mProc, ref CurrentDecode, CurrentDecode.Op1Add + 4, lBase);
+            if (CurrentDecode.Op1.Register != eGeneralRegister.NONE)
+                mProc.mem.SetDWord(mProc, ref CurrentDecode, CurrentDecode.Op1Add,
+                                   (DWord)(mProc.regs.LDTR.SegSel & 0xFFFF));
+            else
+                mProc.mem.SetWord(mProc, ref CurrentDecode, CurrentDecode.Op1Add,
+                                  (Word)mProc.regs.LDTR.SegSel);
 
             #region Instructions
             #endregion


### PR DESCRIPTION
## Summary
- revise SLDT so it stores only the LDTR segment selector per Intel spec

## Testing
- `dotnet build Virtual8086/Virtual80x86.csproj -p:EnableWindowsTargeting=true`
- `dotnet msbuild Virtual80x86Tests/Virtual80x86Tests.csproj -p:EnableWindowsTargeting=true` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a795c4cf808322a9f1d799907fcfa9