### PR TITLE
Clear AF flag for XOR instruction

### DIFF
--- a/Virtual8086/Instructions.cs
+++ b/Virtual8086/Instructions.cs
@@ -10791,7 +10791,8 @@ break;
             mProc.regs.setFlagOF(false);
             mProc.regs.setFlagPF(lOp1Value.OpQWord);
             mProc.regs.setFlagZF(lOp1Value.OpQWord);
-            //AF flag undefined
+            mProc.regs.setFlagAF(false);
+            //AF flag cleared
 
             #region Instructions
             #endregion


### PR DESCRIPTION
## Summary
- clear Auxiliary Carry flag during XOR instruction

## Testing
- `dotnet build Virtual8086/Virtual80x86.csproj -p:EnableWindowsTargeting=true`
- `dotnet build Virtual80x86Tests/Virtual80x86Tests.csproj -p:EnableWindowsTargeting=true` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a2f6a2bc83228f96706049cb2685